### PR TITLE
Improve visibility of matching bracket highlight

### DIFF
--- a/jupyterthemes/styles/solarizedl.less
+++ b/jupyterthemes/styles/solarizedl.less
@@ -85,7 +85,7 @@ http://ethanschoonover.com/solarized
 @prompt-hover-color:    @disabled;
 @prompt-line:           #bbc4c5;
 @tc-prompt-std:         rgba(181, 137, 0, .4);
-@matching-bracket:      @solar-base3;
+@matching-bracket:      @solar-base1;
 @menubar-bg:            darken(@notebook-bg, 3%);
 @menubar-fg:            @notebook-fg;
 @menubar-hover:         @dropdown-bg;


### PR DESCRIPTION
Highlighting the matching bracket with @solar-base3 with the solarized light background color led to the matching pair blending in with the background. Changing to @solar-base1 improves visibility.